### PR TITLE
Define ingress class for docker-registry

### DIFF
--- a/docker-registry/Chart.yaml
+++ b/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.10.0
+version: 1.11.0
 appVersion: 2.8.1
 home: https://hub.docker.com/_/registry/
 icon: https://s3.amazonaws.com/videos.pentesteracademy.com/videos/badges/low/dockerregistry.png

--- a/docker-registry/README.md
+++ b/docker-registry/README.md
@@ -83,6 +83,7 @@ their default values.
 | `affinity`                  | affinity settings                                                                          | `{}`            |
 | `tolerations`               | pod tolerations                                                                            | `[]`            |
 | `ingress.enabled`           | If true, Ingress will be created                                                           | `false`         |
+| `ingress.ingressClassName`  | Defines the ingressClass to be used                                                        | `nginx`         |
 | `ingress.annotations`       | Ingress annotations                                                                        | `{}`            |
 | `ingress.labels`            | Ingress labels                                                                             | `{}`            |
 | `ingress.path`              | Ingress service path                                                                       | `/`             |

--- a/docker-registry/templates/ingress.yaml
+++ b/docker-registry/templates/ingress.yaml
@@ -19,6 +19,7 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  ingressClassName: {{- .Values.ingress.ingressClassName }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}

--- a/docker-registry/values.yaml
+++ b/docker-registry/values.yaml
@@ -30,6 +30,7 @@ service:
   # foo.io/bar: "true"
 ingress:
   enabled: false
+  ingressClassName: nginx
   path: /
   # Used to create an Ingress record.
   hosts:


### PR DESCRIPTION
Defines ingressClassName, annotation based ingress class settings are now deprecated, however works in most of the cases (e.g. ingress-nginx)

https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
